### PR TITLE
Switch to v0.3.2 (tag) instead of develop (branch)

### DIFF
--- a/oai-epc/config.yaml
+++ b/oai-epc/config.yaml
@@ -1,6 +1,6 @@
 options:
    branch:
-     default: "develop"
+     default: "v0.3.2"
      description: |
        branch indicates which installation you want to do. 
      type: string

--- a/oai-epc/hooks/install
+++ b/oai-epc/hooks/install
@@ -71,7 +71,6 @@ clone_repro(){
 	cd $openair_path 
 	git reset --hard HEAD
 	git checkout $branch 
-	git pull
 	shopt -s nocasematch 
 	if [[ "$revision" != "HEAD" ]]; then  
 	    git checkout $revision

--- a/oai-hss/config.yaml
+++ b/oai-hss/config.yaml
@@ -1,6 +1,6 @@
 options:
    branch:
-     default: "develop"
+     default: "v0.3.2"
      description: |
        branch indicates which installation you want to do. If you want an stable installation, change this option to "master". 
      type: string

--- a/oai-hss/hooks/install
+++ b/oai-hss/hooks/install
@@ -69,7 +69,6 @@ clone_repo(){
 	cd $openair_path
 	git reset --hard HEAD 
 	git checkout $branch 
-	git pull 
 	shopt -s nocasematch
 	if [[ "$revision" != "HEAD" ]]; then 
 	    git checkout $revision

--- a/oai-mme/config.yaml
+++ b/oai-mme/config.yaml
@@ -1,6 +1,6 @@
 options:
    branch:
-     default: "develop.old.05.10.2017"
+     default: "v0.3.2"
      description: |
        branch indicates which installation you want to do. If you want a stable installation, change this option to "master". 
      type: string

--- a/oai-mme/hooks/install
+++ b/oai-mme/hooks/install
@@ -109,8 +109,9 @@ clone_repo(){
     else
        #Save the current hosts file
        cp -f /etc/hosts /home
-       git clone --branch $branch https://github.com/OPENAIRINTERFACE/openair-cn $openair_path
+       git clone https://github.com/OPENAIRINTERFACE/openair-cn $openair_path
        cd $openair_path 
+       git checkout $branch
        if [ "$revision" != "head" ]; then 
            git checkout $revision
        fi

--- a/oai-spgw/config.yaml
+++ b/oai-spgw/config.yaml
@@ -1,6 +1,6 @@
 options:
    branch:
-     default: "develop"
+     default: "v0.3.2"
      description: |
        branch indicates which installation you want to do. If you want a stable installation, change this option to "master". 
      type: string

--- a/oai-spgw/hooks/install
+++ b/oai-spgw/hooks/install
@@ -118,11 +118,12 @@ clone_repo(){
     else
        #Save the current hosts file
        cp -f /etc/hosts /home
-       git clone --branch $branch https://github.com/OPENAIRINTERFACE/openair-cn $openair_path
+       git clone https://github.com/OPENAIRINTERFACE/openair-cn $openair_path
        cd $openair_path 
        if [ "$revision" != "head" ]; then 
            git checkout $revision
        fi
+       git checkout $branch
        cd -
     fi
 


### PR DESCRIPTION
It selects the tag closed to the former v0.3.2-branch [1].
It allows passing juju_epc (Functest).

[1] https://github.com/RebacaInc/abot_charm/blob/2ddd7f49854496b7fc8bd44e62b325955a849658/oai-epc/config.yaml

Signed-off-by: Cédric Ollivier <ollivier.cedric@gmail.com>