### PR TITLE
Switch to https://kernel.ubuntu.com

### DIFF
--- a/oai-epc/utils/common
+++ b/oai-epc/utils/common
@@ -130,7 +130,7 @@ sed -r -i "/OUTPUT/ s/\".*\"/\"CONSOLE\"/" $epc_conf_path/epc.conf
 
 install_required_kernel(){
 version=3.19
-wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" http://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
+wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
 dpkg -i kernel.ubuntu.com/*/*/*/*deb
 }
 

--- a/oai-hss/utils/common
+++ b/oai-hss/utils/common
@@ -136,7 +136,7 @@ fi
 
 install_required_kernel(){
 version=3.19
-wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" http://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
+wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
 dpkg -i kernel.ubuntu.com/*/*/*/*deb
 }
 

--- a/oai-mme/utils/common
+++ b/oai-mme/utils/common
@@ -171,9 +171,9 @@ install_required_kernel(){
   version=3.19
 
   if [ "$(cat $CHARM_DIR/.kernel)" == "lowlatency" ]; then 
-      wget -r -e robots=off --accept-regex "(.*lowlatency.*amd64)|(all).deb" http://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
+      wget -r -e robots=off --accept-regex "(.*lowlatency.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
   else
-      wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" http://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
+      wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
   fi
 
   dpkg -i kernel.ubuntu.com/*/*/*/*deb


### PR DESCRIPTION
All deb downloads currently fail [1] then juju_epc can't pass.

[1] https://artifacts.opnfv.org/logs/functest/lf-pod1/gambia/2019-01-04_06-53-40/functest.log

(cherry picked from commit 174bfdd9c7f06394dd24d05e8db70436220bb73f)