### PR TITLE
Swith to linux-image-4.19.0-61-lowlatency

### DIFF
--- a/oai-epc/utils/common
+++ b/oai-epc/utils/common
@@ -129,9 +129,7 @@ sed -r -i "/OUTPUT/ s/\".*\"/\"CONSOLE\"/" $epc_conf_path/epc.conf
 }
 
 install_required_kernel(){
-version=3.19
-wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
-dpkg -i kernel.ubuntu.com/*/*/*/*deb
+  apt-get install -y linux-image-3.19.0-61-lowlatency linux-headers-3.19.0-61-lowlatency
 }
 
 check_current_kernel(){

--- a/oai-hss/utils/common
+++ b/oai-hss/utils/common
@@ -135,9 +135,7 @@ fi
 }
 
 install_required_kernel(){
-version=3.19
-wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
-dpkg -i kernel.ubuntu.com/*/*/*/*deb
+  apt-get install -y linux-image-3.19.0-61-lowlatency linux-headers-3.19.0-61-lowlatency
 }
 
 check_current_kernel(){

--- a/oai-mme/config.yaml
+++ b/oai-mme/config.yaml
@@ -9,8 +9,8 @@ options:
      description: get a specific revison from the openair-cn git repository. 
      type: string
    kernel: 
-     default: "generic"
-     description: set the default kerenl, generic or lowlatency. 
+     default: "lowlatency"
+     description: set the default kernel, generic or lowlatency. 
      type: string
    realm:
      default: "openair4G.eur"

--- a/oai-mme/utils/common
+++ b/oai-mme/utils/common
@@ -168,15 +168,7 @@ user_conf(){
 }
 
 install_required_kernel(){
-  version=3.19
-
-  if [ "$(cat $CHARM_DIR/.kernel)" == "lowlatency" ]; then 
-      wget -r -e robots=off --accept-regex "(.*lowlatency.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
-  else
-      wget -r -e robots=off --accept-regex "(.*generic.*amd64)|(all).deb" https://kernel.ubuntu.com/~kernel-ppa/mainline/v${version}-vivid/
-  fi
-
-  dpkg -i kernel.ubuntu.com/*/*/*/*deb
+  apt-get install -y linux-image-3.19.0-61-lowlatency linux-headers-3.19.0-61-lowlatency
 }
 
 check_current_kernel(){


### PR DESCRIPTION
It conforms with the official documentation [1].
The former kernel cannot be downloaded (404).

[1] https://gitlab.eurecom.fr/oai/openairinterface5g/wikis/OpenAirKernelMainSetup

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>
(cherry picked from commit d7711dfa271550a2f794ddb8327e4e6ec31cfeaf)