### PR TITLE
Switch ABOT_URL to artifacts.opnfv.org

### DIFF
--- a/abot-epc-basic/install-abot.sh
+++ b/abot-epc-basic/install-abot.sh
@@ -339,7 +339,7 @@ done
 check_input
 
 ABOT_DIR=/var/lib/${APP_NAME}
-ABOT_URL="http://115.249.81.187:8080/rebaca"
+ABOT_URL="http://artifacts.opnfv.org/functest/epc"
 ABOT_DEBIAN=${APP_NAME}_${APP_VERSION}_all.deb
 
 # Installing dependencies for abot-volte-basic

--- a/abot-ims-basic/install-abot.sh
+++ b/abot-ims-basic/install-abot.sh
@@ -339,7 +339,7 @@ done
 check_input
 
 ABOT_DIR=/var/lib/${APP_NAME}
-ABOT_URL="http://115.249.81.187:8080/rebaca"
+ABOT_URL="http://artifacts.opnfv.org/functest/epc"
 ABOT_DEBIAN=${APP_NAME}_${APP_VERSION}_all.deb
 
 # Installing dependencies for abot-volte-basic


### PR DESCRIPTION
It downlads abot-functest-basic_3.1.1_all.deb from
http://artifacts.opnfv.org/functest/epc/ as Rebacca server is
temporarily unreachable.

Signed-off-by: Cédric Ollivier <cedric.ollivier@orange.com>